### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ https://sophgo.my-ho.st:8443/ which pulls down the compiled debian packages from
 ## Building the Image
 To build a stock image with no modifications:
 ```
-podman run --privileged -it --rm -v ./configs/:/configs -v ./image:/output ghcr.io/fishwaldo/sophgo-sg200x-debian:master make BOARD=licheervnano image
+podman run --privileged -it --rm -v ./configs/:/configs -v ./image:/output ghcr.io/fishwaldo/sophgo-sg200x-debian:mainline make BOARD=licheervnano image
 ```
 
 Replace the licheervnano with the board you want to build for:

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
         git gperf kmod libexpat-dev \
         libgmp-dev libmpc-dev libmpfr-dev libssl-dev \
         libtool mmdebstrap openssl parted \
-        patchutils python3 python3-dev python3-setuputils \
+        patchutils python3 python3-dev \
         python3-setuptools  swig gnupg \
         systemd-container texinfo zlib1g-dev wget arch-test \
         linux-image-generic genimage joe mc zip \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
         git gperf kmod libexpat-dev \
         libgmp-dev libmpc-dev libmpfr-dev libssl-dev \
         libtool mmdebstrap openssl parted \
-        patchutils python3 python3-dev python3-distutils \
+        patchutils python3 python3-dev python3-setuputils \
         python3-setuptools  swig gnupg \
         systemd-container texinfo zlib1g-dev wget arch-test \
         linux-image-generic genimage joe mc zip \

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -198,6 +198,10 @@ $(BUILDDIR)/image-prepare-stamp:
 	@-rm $(addon-targets)
 	@mkdir -p /rootfs/
 	@curl -s https://sophgo.my-ho.st:8443/public-key.asc -o $(BUILDDIR)/public-key.asc
+#       @apt-key add $(BUILDDIR)/public-key.asc
+#       @gpg import $(BUILDDIR)/public-key.asc
+        @curl -sSL https://sophgo.my-ho.st:8443/public-key.asc | gpg --import -
+ 
 	@apt-key add $(BUILDDIR)/public-key.asc
 	@mmdebstrap -v --architectures=riscv64 --include="$(_PACKAGES)" sid "/rootfs/" "deb http://deb.debian.org/debian/ sid main" "deb https://sophgo.my-ho.st:8443/ debian sophgo"
 	@touch $@


### PR DESCRIPTION
GitHub now uses `mainline' rather than `master'.  Updating the 'build image' command.

Changed to work under the new configuration.